### PR TITLE
support new versions of HHVM

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,5 @@
 	},
 	"scripts": {
 		"tests": "env hhvm vendor/bin/hacktest tests"
-	},
-	"config": {
-		"platform": {
-			"hhvm": "4.1.0"
-		}
 	}
 }

--- a/src/Uri.hack
+++ b/src/Uri.hack
@@ -333,6 +333,7 @@ final class Uri implements UriInterface {
   }
 
   private function filterPath(string $path): string {
+    $_count = null;
     return \preg_replace_callback(
       '/(?:[^'.
       static::$char_unreserved.
@@ -342,10 +343,13 @@ final class Uri implements UriInterface {
         return \rawurlencode($match[0]);
       },
       $path,
+      -1,
+      inout $_count,
     );
   }
 
   private function filterQueryAndFragment(string $str): string {
+    $_count = null;
     return \preg_replace_callback(
       '/(?:[^'.
       static::$char_unreserved.
@@ -355,6 +359,8 @@ final class Uri implements UriInterface {
         return \rawurlencode($match[0]);
       },
       $str,
+      -1,
+      inout $_count,
     );
   }
 


### PR DESCRIPTION
`preg_replace_callback` was changed recently so that previously optional by-ref arguments are now non-optional inout arguments