### PR TITLE
add namespace to example script

### DIFF
--- a/example/index.hack
+++ b/example/index.hack
@@ -1,3 +1,5 @@
+namespace Usox\HackTTP\Example;
+
 require_once '../vendor/hh_autoload.hh';
 
 <<__EntryPoint>>


### PR DESCRIPTION
It's preferable to not have a function with a common name (`\main()`) in the global namespace.

Alternatively, it might be possible to set it up such that the `example` directory is not installed with the Composer package, but I don't know enough about Composer to do that :/