### PR TITLE
support HSL 4.25+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 vendor
+*.hhast.parser-cache

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
 	"require": {
 		"hhvm": "^4.1",
 		"facebook/hack-http-request-response-interfaces": "^0.2",
-		"hhvm/hsl": "^4.1",
-		"hhvm/hsl-experimental": "^4.1",
+		"hhvm/hsl": "^4.25",
+		"hhvm/hsl-experimental": "^4.25",
 		"hhvm/type-assert": "^3.3",
 		"usox/hack-http-factory-interfaces": "^0.2"
 	},

--- a/src/Marshaler/UploadedFileMarshaler.hack
+++ b/src/Marshaler/UploadedFileMarshaler.hack
@@ -11,7 +11,7 @@ namespace Usox\HackTTP\Marshaler;
 
 use namespace Facebook\Experimental\Http\Message;
 use type Usox\HackTTP\UploadedFile;
-use namespace HH\Lib\{C, Experimental\Filesystem, Str};
+use namespace HH\Lib\{C, Experimental\File, Str};
 
 type UploadedFileType = shape(
 	'tmp_name' => string,
@@ -72,7 +72,7 @@ final class UploadedFileMarshaler implements UploadedFileMarshalerInterface {
 		$error = $file['error'] === 0 ? null : Message\UploadedFileError::assert($file['error']);
 
 		return new UploadedFile(
-			Filesystem\open_read_only_non_disposable($file['tmp_name']),
+			File\open_read_only_nd($file['tmp_name']),
 			$file['size'],
 			$error,
 			$file['name'] ?? '',

--- a/src/Request.hack
+++ b/src/Request.hack
@@ -10,7 +10,7 @@
 namespace Usox\HackTTP;
 
 use namespace Facebook\Experimental\Http\Message;
-use namespace HH\Lib\{C, Experimental\IO, Dict};
+use namespace HH\Lib\{C, Dict, Experimental\IO};
 
 class Request implements Message\RequestInterface {
 

--- a/src/RequestFactory.hack
+++ b/src/RequestFactory.hack
@@ -22,7 +22,7 @@ final class RequestFactory implements RequestFactoryInterface {
     return new Request(
       $method,
       $uri,
-      IO\server_input(),
+      IO\request_input(),
       dict[]
     );
   }

--- a/src/UploadedFile.hack
+++ b/src/UploadedFile.hack
@@ -10,7 +10,7 @@
 namespace Usox\HackTTP;
 
 use namespace Facebook\Experimental\Http\Message;
-use namespace HH\Lib\{Experimental\IO, Experimental\Filesystem, Str};
+use namespace HH\Lib\{Experimental\File, Experimental\IO, Str};
 
 final class UploadedFile implements Message\UploadedFileInterface {
 
@@ -51,9 +51,11 @@ final class UploadedFile implements Message\UploadedFileInterface {
   }
 
   private async function writeAsync(string $target_path): Awaitable<void> {
-    await using $target = Filesystem\open_write_only($target_path);
+    await using $target = File\open_write_only($target_path);
     await $target->writeAsync($this->stream->rawReadBlocking());
-    await $this->stream->closeAsync();
+    if ($this->stream is IO\NonDisposableHandle) {
+      await $this->stream->closeAsync();
+    }
   }
 
   public function getSize(): ?int {

--- a/src/Uri.hack
+++ b/src/Uri.hack
@@ -75,7 +75,7 @@ final class Uri implements UriInterface {
 
     if ($this->raw_query !== '') {
       $uri .= '?'.$this->raw_query;
-    } elseif (C\count($this->query) > 0) {
+    } else if (C\count($this->query) > 0) {
       $uri .= Str\format(
         '?%s',
         Dict\map_with_key(
@@ -387,7 +387,7 @@ final class Uri implements UriInterface {
           'A relative URI must not have a path beginning with a segment containing a colon',
         );
       }
-    } elseif ($path !== '' && Str\search($path, '/') !== 0) {
+    } else if ($path !== '' && Str\search($path, '/') !== 0) {
       throw new \InvalidArgumentException(
         'The path of a URI with an authority must start with a slash "/" or be empty',
       );

--- a/src/functions.hack
+++ b/src/functions.hack
@@ -10,7 +10,7 @@
 namespace Usox\HackTTP;
 
 use namespace Facebook\Experimental\Http\Message;
-use namespace HH\Lib\{Experimental\Filesystem, Experimental\IO};
+use namespace HH\Lib\Experimental\{File, IO};
 
 /**
  * We still have to rely on good old php's super globals, so provide a
@@ -59,9 +59,9 @@ function create_response(
 	int $code = 200,
 	string $reason = '',
 ): Message\ResponseInterface {
-	$write_handle = Filesystem\open_write_only_non_disposable(
+	$write_handle = File\open_write_only_nd(
 		\sys_get_temp_dir().'/'.\bin2hex(\random_bytes(16)),
-		Filesystem\FileWriteMode::MUST_CREATE
+		File\WriteMode::MUST_CREATE
 	);
 	return new Response($write_handle, $code, $reason);
 }

--- a/tests/Response/TemporaryFileSapiEmitterTest.hack
+++ b/tests/Response/TemporaryFileSapiEmitterTest.hack
@@ -11,7 +11,7 @@ namespace Usox\HackTTP\Response;
 
 use namespace Facebook\Experimental\Http\Message;
 use type Facebook\HackTest\HackTest;
-use namespace HH\Lib\Experimental\Filesystem;
+use namespace HH\Lib\Experimental\File;
 use function Usox\HackMock\{mock, prospect};
 
 class TemporaryFileSapiEmitterTest extends HackTest {
@@ -30,8 +30,8 @@ class TemporaryFileSapiEmitterTest extends HackTest {
 		\file_put_contents($path, $body_value);
 
 		$response = mock(Message\ResponseInterface::class);
-		$handle = mock(Filesystem\FileHandle::class);
-		$path_handle = mock(Filesystem\Path::class);
+		$handle = mock(File\Handle::class);
+		$path_handle = mock(File\Path::class);
 
 		prospect($handle, 'getPath')
 			->once()

--- a/tests/UploadedFileTest.hack
+++ b/tests/UploadedFileTest.hack
@@ -10,7 +10,7 @@
 namespace Usox\HackTTP;
 
 use namespace Facebook\Experimental\Http\Message;
-use namespace HH\Lib\{Experimental\IO, Experimental\Filesystem};
+use namespace HH\Lib\{Experimental\File, Experimental\IO};
 use type Facebook\HackTest\HackTest;
 use function Facebook\FBExpect\expect;
 use function Usox\HackMock\{mock, prospect};
@@ -104,7 +104,7 @@ class UploadedFileTest extends HackTest {
 
     $file->moveTo($filename);
 
-    $target_file = Filesystem\open_read_only_non_disposable($filename);
+    $target_file = File\open_read_only_nd($filename);
 
     expect($target_file->rawReadBlocking())
       ->toBeSame($content);


### PR DESCRIPTION
There's been a lot of naming changes in hsl and hsl-experimental v4.25 (e.g. `Filesystem` -> `File`, `non_disposable` -> `nd`).

Some minor changes are also because of lint warnings that I'm guessing were added in recent versions of hhast (e.g. `elseif`, alphabetical ordering in `use`).