### PR TITLE
fix renamed IO interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		"hhvm": "^4.1",
 		"facebook/hack-http-request-response-interfaces": "^0.2",
 		"hhvm/hsl": "^4.25",
-		"hhvm/hsl-experimental": "^4.25",
+		"hhvm/hsl-experimental": "^4.37",
 		"hhvm/type-assert": "^3.3",
 		"usox/hack-http-factory-interfaces": "^0.2"
 	},

--- a/src/Response/TemporaryFileSapiEmitter.hack
+++ b/src/Response/TemporaryFileSapiEmitter.hack
@@ -44,7 +44,7 @@ final class TemporaryFileSapiEmitter implements EmitterInterface {
 
 		$temporary_file_path = $path->toString();
 
-		if ($body is IO\NonDisposableHandle) {
+		if ($body is IO\CloseableHandle) {
 			await $body->closeAsync();
 		}
 

--- a/src/UploadedFile.hack
+++ b/src/UploadedFile.hack
@@ -53,7 +53,7 @@ final class UploadedFile implements Message\UploadedFileInterface {
   private async function writeAsync(string $target_path): Awaitable<void> {
     await using $target = File\open_write_only($target_path);
     await $target->writeAsync($this->stream->rawReadBlocking());
-    if ($this->stream is IO\NonDisposableHandle) {
+    if ($this->stream is IO\CloseableHandle) {
       await $this->stream->closeAsync();
     }
   }


### PR DESCRIPTION
`NonDisposableHandle` was renamed to `CloseableHandle` in hsl-experimental 4.37