### PR TITLE
support (and require) hsl-experimental v4.50

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
 	],
 	"require": {
 		"hhvm": "^4.1",
-		"facebook/hack-http-request-response-interfaces": "^0.2",
+		"facebook/hack-http-request-response-interfaces": "^0.3",
 		"hhvm/hsl": "^4.25",
-		"hhvm/hsl-experimental": "^4.37",
+		"hhvm/hsl-experimental": "^4.50",
 		"hhvm/type-assert": "^3.3",
 		"usox/hack-http-factory-interfaces": "^0.2"
 	},

--- a/src/Marshaler/UploadedFileMarshaler.hack
+++ b/src/Marshaler/UploadedFileMarshaler.hack
@@ -11,7 +11,7 @@ namespace Usox\HackTTP\Marshaler;
 
 use namespace Facebook\Experimental\Http\Message;
 use type Usox\HackTTP\UploadedFile;
-use namespace HH\Lib\{C, Experimental\File, Str};
+use namespace HH\Lib\{C, File, Str};
 
 type UploadedFileType = shape(
 	'tmp_name' => string,

--- a/src/Request.hack
+++ b/src/Request.hack
@@ -10,7 +10,7 @@
 namespace Usox\HackTTP;
 
 use namespace Facebook\Experimental\Http\Message;
-use namespace HH\Lib\{C, Dict, Experimental\IO};
+use namespace HH\Lib\{C, Dict, IO};
 
 class Request implements Message\RequestInterface {
 

--- a/src/RequestFactory.hack
+++ b/src/RequestFactory.hack
@@ -9,7 +9,7 @@
 
 namespace Usox\HackTTP;
 
-use namespace HH\Lib\Experimental\IO;
+use namespace HH\Lib\IO;
 use namespace Facebook\Experimental\Http\Message;
 use type Usox\HackHttpFactory\RequestFactoryInterface;
 

--- a/src/Response.hack
+++ b/src/Response.hack
@@ -10,7 +10,7 @@
 namespace Usox\HackTTP;
 
 use namespace Facebook\Experimental\Http\Message;
-use namespace HH\Lib\{C, Experimental\IO};
+use namespace HH\Lib\{C, IO};
 
 class Response implements Message\ResponseInterface {
 

--- a/src/Response/TemporaryFileSapiEmitter.hack
+++ b/src/Response/TemporaryFileSapiEmitter.hack
@@ -9,7 +9,7 @@
 
 namespace Usox\HackTTP\Response;
 
-use namespace HH\Lib\{Experimental\File, Experimental\IO, Math, Str};
+use namespace HH\Lib\{File, IO, Math, Str};
 use type Facebook\Experimental\Http\Message\ResponseInterface;
 use type Usox\HackTTP\Exception\EmitterException;
 

--- a/src/ResponseFactory.hack
+++ b/src/ResponseFactory.hack
@@ -9,7 +9,7 @@
 
 namespace Usox\HackTTP;
 
-use namespace HH\Lib\Experimental\IO;
+use namespace HH\Lib\IO;
 use namespace Facebook\Experimental\Http\Message;
 use type Usox\HackHttpFactory\ResponseFactoryInterface;
 

--- a/src/ServerRequest.hack
+++ b/src/ServerRequest.hack
@@ -9,7 +9,7 @@
 
 namespace Usox\HackTTP;
 
-use namespace HH\Lib\Experimental\IO;
+use namespace HH\Lib\IO;
 use namespace Facebook\Experimental\Http\Message;
 
 final class ServerRequest

--- a/src/ServerRequestFactory.hack
+++ b/src/ServerRequestFactory.hack
@@ -9,7 +9,7 @@
 
 namespace Usox\HackTTP;
 
-use namespace HH\Lib\Experimental\IO;
+use namespace HH\Lib\IO;
 use namespace Facebook\Experimental\Http\Message;
 use type Usox\HackHttpFactory\ServerRequestFactoryInterface;
 

--- a/src/UploadedFile.hack
+++ b/src/UploadedFile.hack
@@ -10,7 +10,7 @@
 namespace Usox\HackTTP;
 
 use namespace Facebook\Experimental\Http\Message;
-use namespace HH\Lib\{Experimental\File, Experimental\IO, Str};
+use namespace HH\Lib\{File, IO, Str};
 
 final class UploadedFile implements Message\UploadedFileInterface {
 

--- a/src/functions.hack
+++ b/src/functions.hack
@@ -10,7 +10,7 @@
 namespace Usox\HackTTP;
 
 use namespace Facebook\Experimental\Http\Message;
-use namespace HH\Lib\Experimental\{File, IO};
+use namespace HH\Lib\{File, IO};
 
 /**
  * We still have to rely on good old php's super globals, so provide a

--- a/tests/RequestTest.hack
+++ b/tests/RequestTest.hack
@@ -12,7 +12,7 @@ namespace Usox\HackTTP;
 use namespace Facebook\Experimental\Http\Message;
 use type Facebook\HackTest\HackTest;
 use function Facebook\FBExpect\expect;
-use namespace HH\Lib\{Experimental\IO, Str};
+use namespace HH\Lib\{IO, Str};
 use function Usox\HackMock\{mock, prospect};
 
 class RequestTest extends HackTest {

--- a/tests/Response/TemporaryFileSapiEmitterTest.hack
+++ b/tests/Response/TemporaryFileSapiEmitterTest.hack
@@ -11,7 +11,7 @@ namespace Usox\HackTTP\Response;
 
 use namespace Facebook\Experimental\Http\Message;
 use type Facebook\HackTest\HackTest;
-use namespace HH\Lib\Experimental\File;
+use namespace HH\Lib\File;
 use function Usox\HackMock\{mock, prospect};
 
 class TemporaryFileSapiEmitterTest extends HackTest {

--- a/tests/ResponseTest.hack
+++ b/tests/ResponseTest.hack
@@ -11,7 +11,7 @@ namespace Usox\HackTTP;
 
 use type Facebook\HackTest\HackTest;
 use function Facebook\FBExpect\expect;
-use namespace HH\Lib\Experimental\IO;
+use namespace HH\Lib\IO;
 use function Usox\HackMock\mock;
 
 class ResponseTest extends HackTest {

--- a/tests/ServerRequestTest.hack
+++ b/tests/ServerRequestTest.hack
@@ -9,7 +9,7 @@
 
 namespace Usox\HackTTP;
 
-use namespace HH\Lib\Experimental\IO;
+use namespace HH\Lib\IO;
 use type Facebook\HackTest\HackTest;
 use function Facebook\FBExpect\expect;
 use function Usox\HackMock\{mock, prospect};

--- a/tests/UploadedFileTest.hack
+++ b/tests/UploadedFileTest.hack
@@ -10,7 +10,7 @@
 namespace Usox\HackTTP;
 
 use namespace Facebook\Experimental\Http\Message;
-use namespace HH\Lib\{Experimental\File, Experimental\IO};
+use namespace HH\Lib\{File, IO};
 use type Facebook\HackTest\HackTest;
 use function Facebook\FBExpect\expect;
 use function Usox\HackMock\{mock, prospect};


### PR DESCRIPTION
https://github.com/hhvm/hsl-experimental/releases/tag/v4.50.0

This release removes "Experimental" from all namespace names.

This depends on https://github.com/usox/hack-http-factory-interfaces/pull/1 (without it `composer install` will fail because of the conflicting facebook/hack-http-request-response-interfaces version requirements).