### PR TITLE
Support (and require) hsl-experimental 4.52

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
 		}
 	],
 	"require": {
-		"hhvm": "^4.1",
+		"hhvm": "^4.52",
 		"facebook/hack-http-request-response-interfaces": "^0.3",
 		"hhvm/hsl": "^4.25",
-		"hhvm/hsl-experimental": "^4.50",
+		"hhvm/hsl-experimental": "^4.52",
 		"hhvm/type-assert": "^3.3",
 		"usox/hack-http-factory-interfaces": "^0.2"
 	},


### PR DESCRIPTION
Upstream changes:
- blocking functions renamed
- readAsync/writeAsync no longer deal with the whole thing

Other changes made here:

- do a chunked copy instead of using readAll/writeAll to reduce peak
  memory
- that means we're making multiple calls with different return values,
  which I don't see how to mock. Use a pipe handle instead of a
  mock in the unit test.