### PR TITLE
Depend on new hsl-io virtual package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
 		"facebook/hack-http-request-response-interfaces": "^0.3",
 		"hhvm/hsl": "^4.25",
 		"hhvm/hsl-experimental": "^4.52",
+		"hhvm/hsl-io": "^0.1.0",
 		"hhvm/type-assert": "^3.3",
 		"usox/hack-http-factory-interfaces": "^0.2"
 	},


### PR DESCRIPTION
Should mean that projects using hackttp will not update to incompatible
hsl-experimental versions until HackTTP is updated