### PR TITLE
Permit type-assert v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"facebook/hack-http-request-response-interfaces": "^0.3",
 		"hhvm/hsl": "^4.25",
 		"hhvm/hsl-experimental": "^4.52",
-		"hhvm/type-assert": "^3.3",
+		"hhvm/type-assert": "^3.3|^4.0",
 		"usox/hack-http-factory-interfaces": "^0.2"
 	},
 	"require-dev": {


### PR DESCRIPTION
Tested by:

- removing require-dev section
- removing tests/
- hh_client
- re-adding tests, grepping for `vec_like_array` and `dict_like_array`

Related PR also up for hackmock