### PR TITLE
replace is_array() call

### DIFF
--- a/src/Marshaler/UploadedFileMarshaler.hack
+++ b/src/Marshaler/UploadedFileMarshaler.hack
@@ -42,24 +42,24 @@ final class UploadedFileMarshaler implements UploadedFileMarshalerInterface {
 	public function marshal(dict<string, mixed> $files): dict<string, Message\UploadedFileInterface> {
 		$result = dict[];
 		foreach ($files as $index_name => $file_entry) {
-			if (!\is_array($file_entry)) {
+			if (!$file_entry is KeyedContainer<_, _>) {
 				continue;
 			}
 
 			if ($file_entry is UploadedFileType) {
 				$result[$index_name] = $this->createUploadedFile($file_entry);
 			} else {
-				$file_count = C\count($file_entry['tmp_name']);
+				$file_count = C\count($file_entry['tmp_name'] as Container<_>);
 				for ($i = 0; $i < $file_count; $i++) {
 					$key = Str\format('%s[%d]', $index_name, $i);
 					$result[$key] = $this->createUploadedFile(
 						shape(
-							'tmp_name' => $file_entry['tmp_name'][$i],
-							'size' => $file_entry['size'][$i],
-							'error' => $file_entry['error'][$i],
-							'type' => $file_entry['type'][$i] ?? null,
-							'name' => $file_entry['name'][$i] ?? null
-						)
+							'tmp_name' => $file_entry['tmp_name'] as KeyedContainer<_, _>[$i],
+							'size' => $file_entry['size'] as KeyedContainer<_, _>[$i],
+							'error' => $file_entry['error'] as KeyedContainer<_, _>[$i],
+							'type' => $file_entry['type'] as KeyedContainer<_, _>[$i] ?? null,
+							'name' => $file_entry['name'] as KeyedContainer<_, _>[$i] ?? null,
+						) as UploadedFileType,
 					);
 				}
 			}


### PR DESCRIPTION
The `is_array()` function was removed in the latest HHVM release.

`$var is ...` has better typechecker support than `is_array()`, which revealed some previously untyped code, so I had to add additional assertions there.